### PR TITLE
[회원] 입력값 검증 로직 추가

### DIFF
--- a/src/main/java/com/ite/pickon/domain/user/controller/UserController.java
+++ b/src/main/java/com/ite/pickon/domain/user/controller/UserController.java
@@ -3,6 +3,7 @@ package com.ite.pickon.domain.user.controller;
 import com.ite.pickon.domain.user.UserStatus;
 import com.ite.pickon.domain.user.dto.UserVO;
 import com.ite.pickon.domain.user.service.UserService;
+import com.ite.pickon.validator.UserValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.java.Log;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,7 +11,11 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Controller;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
 import org.springframework.web.bind.annotation.*;
+import java.util.HashMap;
+import java.util.Map;
 
 import javax.servlet.http.HttpSession;
 
@@ -21,24 +26,31 @@ public class UserController {
 
     private final UserService userService;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
+    private final UserValidator validator;
 
     @Autowired
     public UserController(UserService userService, BCryptPasswordEncoder bCryptPasswordEncoder) {
         this.userService = userService;
         this.bCryptPasswordEncoder = bCryptPasswordEncoder;
+        this.validator = new UserValidator();
     }
+
     @PostMapping("/register")
-    public ResponseEntity<?> userAdd(@RequestBody UserVO user) {
+    public ResponseEntity<?> userAdd(@RequestBody UserVO user, BindingResult bindingResult, HttpSession session) {
+        validator.validate(user, bindingResult);
+
+        // 입력값 검증 로직 추가
+        if (bindingResult.hasErrors()) {
+            return new ResponseEntity<>(createErrorMap(bindingResult), HttpStatus.BAD_REQUEST);
+        }
+
         try {
             // 사용자 등록
             user.setRole("general");
             user.setStatus(UserStatus.ACTIVE);
 
-            /**
-             * 패스워드 인코딩 설정
-             */
+            // 패스워드 인코딩 설정 추가
             user.setPassword(bCryptPasswordEncoder.encode(user.getPassword()));
-            System.out.println(user.getPassword());
             userService.addUser(user);
             return ResponseEntity.ok("Registration successful! Please login.");
         } catch (Exception e) {
@@ -49,9 +61,8 @@ public class UserController {
     @PostMapping("/login")
     public ResponseEntity<?> userLogin(@RequestBody UserVO user, HttpSession session) {
         String password = userService.findByUsername(user.getUsername()).getPassword();
-        /**
-         * 패스워드 일치 여부 확인
-         */
+
+        // 패스워드 일치 여부 확인
         if (bCryptPasswordEncoder.matches(user.getPassword(), password)) {
             session.setAttribute("user", user);
             return ResponseEntity.ok("Registration successful! Please login.");
@@ -76,6 +87,14 @@ public class UserController {
         userService.removeUser(user.getUsername());
         session.invalidate();
         return ResponseEntity.ok("User deactivated");
+    }
+
+    private Map<String, String> createErrorMap(BindingResult bindingResult) {
+        Map<String, String> errors = new HashMap<>();
+        for (FieldError error : bindingResult.getFieldErrors()) {
+            errors.put(error.getField(), error.getDefaultMessage());
+        }
+        return errors;
     }
 
 }

--- a/src/main/java/com/ite/pickon/validator/UserValidator.java
+++ b/src/main/java/com/ite/pickon/validator/UserValidator.java
@@ -1,0 +1,40 @@
+package com.ite.pickon.validator;
+
+import com.ite.pickon.domain.user.dto.UserVO;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.Errors;
+import org.springframework.validation.ValidationUtils;
+import org.springframework.validation.Validator;
+
+@Component
+public class UserValidator implements Validator {
+
+
+    @Override
+    public boolean supports(Class<?> aClass) {
+        return UserVO.class.equals(aClass);
+    }
+
+    @Override
+    public void validate(Object o, Errors errors) {
+        UserVO userVO = (UserVO) o;
+
+        // 사용자 이름 검증
+        ValidationUtils.rejectIfEmptyOrWhitespace(errors, "username", "NotEmpty");
+        if (userVO.getUsername().length() < 3 || userVO.getUsername().length() > 32) {
+            errors.rejectValue("username", "Size.userForm.username", "Username must be between 3 and 32 characters");
+        }
+
+        // 비밀번호 검증
+        ValidationUtils.rejectIfEmptyOrWhitespace(errors, "password", "NotEmpty");
+        if (userVO.getPassword().length() < 8 || userVO.getPassword().length() > 32) {
+            errors.rejectValue("password", "Size.userForm.password", "Password must be between 8 and 32 characters");
+        }
+
+        // 전화번호 검증
+        ValidationUtils.rejectIfEmptyOrWhitespace(errors, "phone_number", "NotEmpty");
+        if (!userVO.getPhone_number().matches("010-\\d{4}-\\d{4}")) {
+            errors.rejectValue("phone_number", "Pattern.userForm.phoneNumber", "Invalid phone number format");
+        }
+    }
+}


### PR DESCRIPTION
## 📋 구현 기능 명세
1.  **입력값 검증 로직 추가**
    - 회원 아이디/패스워드/전화번호 입력값 검증 후 실패 시 에러 내용 담아 반환
    - 아이디의 경우 3~ 32자 이내로 입력
    - 비밀번호의 경우 8~ 32자 이내로 입력
    - 전화번호의 경우 '010-xxxx-xxxx'로 입력

## 📸 결과물 스크린샷
1. **입력값 검증 실패**
<img width="1145" alt="스크린샷 2024-06-18 오전 11 32 14" src="https://github.com/ITE-Project1/pick-on-backend/assets/77055216/c31f0d63-3d4b-4235-acd1-7a1a325cf9c2">
