### PR TITLE
[회원] 관리자 유저 목록 조회 기능 추가

### DIFF
--- a/src/main/java/com/ite/pickon/domain/user/controller/UserController.java
+++ b/src/main/java/com/ite/pickon/domain/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.ite.pickon.domain.user.controller;
 
+import com.ite.pickon.domain.product.dto.ProductAdminVO;
 import com.ite.pickon.domain.user.UserStatus;
 import com.ite.pickon.domain.user.dto.UserVO;
 import com.ite.pickon.domain.user.service.UserService;
@@ -7,6 +8,9 @@ import com.ite.pickon.validator.UserValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.java.Log;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Controller;
@@ -15,13 +19,13 @@ import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.annotation.*;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import javax.servlet.http.HttpSession;
 
 @Log
 @Controller
-@RequestMapping("/user")
 public class UserController {
 
     private final UserService userService;
@@ -35,7 +39,7 @@ public class UserController {
         this.validator = new UserValidator();
     }
 
-    @PostMapping("/register")
+    @PostMapping("/user/register")
     public ResponseEntity<?> userAdd(@RequestBody UserVO user, BindingResult bindingResult, HttpSession session) {
         validator.validate(user, bindingResult);
 
@@ -58,7 +62,7 @@ public class UserController {
         }
     }
 
-    @PostMapping("/login")
+    @PostMapping("/user/login")
     public ResponseEntity<?> userLogin(@RequestBody UserVO user, HttpSession session) {
         String password = userService.findByUsername(user.getUsername()).getPassword();
 
@@ -71,13 +75,13 @@ public class UserController {
         }
     }
 
-    @PostMapping("/logout")
+    @PostMapping("/user/logout")
     public ResponseEntity<?> userLogout(HttpSession session) {
         session.invalidate();
         return ResponseEntity.ok("Logout successful");
     }
 
-    @PatchMapping("/sign-out")
+    @PatchMapping("/user/sign-out")
     public ResponseEntity<?> userRemove(@RequestBody UserVO user, HttpSession session) {
         //UserVO user = (UserVO) session.getAttribute("user");
         if (user == null) {
@@ -87,6 +91,13 @@ public class UserController {
         userService.removeUser(user.getUsername());
         session.invalidate();
         return ResponseEntity.ok("User deactivated");
+    }
+
+    @GetMapping("/admin/users")
+    public ResponseEntity<List<UserVO>> getUserList(@RequestParam int page,
+                                                    @RequestParam(required = false) String keyword) {
+        Pageable pageable = PageRequest.of(page, 10);
+        return new ResponseEntity<>(userService.findUserList(pageable, keyword), HttpStatus.OK);
     }
 
     private Map<String, String> createErrorMap(BindingResult bindingResult) {

--- a/src/main/java/com/ite/pickon/domain/user/mapper/UserMapper.java
+++ b/src/main/java/com/ite/pickon/domain/user/mapper/UserMapper.java
@@ -1,10 +1,16 @@
 package com.ite.pickon.domain.user.mapper;
 
+import com.ite.pickon.domain.product.dto.ProductAdminVO;
 import com.ite.pickon.domain.user.dto.UserVO;
+import org.apache.ibatis.annotations.Param;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
 
 public interface UserMapper {
 
     void insertUser(UserVO user);
     UserVO selectUser(String username);
     void deleteUser(String username);
+    List<UserVO> selectUserListByKeyword(@Param("pageable")Pageable pageable, @Param("keyword")String keyword);
 }

--- a/src/main/java/com/ite/pickon/domain/user/service/UserService.java
+++ b/src/main/java/com/ite/pickon/domain/user/service/UserService.java
@@ -1,11 +1,14 @@
 package com.ite.pickon.domain.user.service;
 
 import com.ite.pickon.domain.user.dto.UserVO;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
 
 public interface UserService {
 
     void addUser(UserVO user);
     UserVO findByUsername(String username);
-
     void removeUser(String username);
+    List<UserVO> findUserList(Pageable pageable, String keyword);
 }

--- a/src/main/java/com/ite/pickon/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/ite/pickon/domain/user/service/UserServiceImpl.java
@@ -1,9 +1,11 @@
 package com.ite.pickon.domain.user.service;
 
 
+import com.ite.pickon.domain.product.dto.ProductAdminVO;
 import com.ite.pickon.domain.user.dto.UserVO;
 import com.ite.pickon.domain.user.mapper.UserMapper;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -34,5 +36,11 @@ public class UserServiceImpl implements UserService {
     public void removeUser(String username) {
         userMapper.deleteUser(username);
     }
+
+    @Override
+    public List<UserVO> findUserList(Pageable pageable, String keyword) {
+        return userMapper.selectUserListByKeyword(pageable, keyword);
+    }
+
 
 }

--- a/src/main/resources/com/ite/pickon/domain/user/mapper/UserMapper.xml
+++ b/src/main/resources/com/ite/pickon/domain/user/mapper/UserMapper.xml
@@ -14,4 +14,14 @@
     <update id="deleteUser">
         UPDATE users SET status = 1 WHERE username = #{username}
     </update>
+
+    <select id="selectUserListByKeyword" parameterType="hashmap" resultType="com.ite.pickon.domain.user.dto.UserVO">
+        SELECT username, password, created_at
+        FROM users
+        <if test="keyword != null and keyword != ''">
+            AND (LOWER(username) LIKE '%' || LOWER(#{keyword}) || '%')
+        </if>
+
+        OFFSET #{pageable.offset} ROWS FETCH NEXT #{pageable.pageSize} ROWS ONLY
+    </select>
 </mapper>


### PR DESCRIPTION
## 📋 구현 기능 명세
1.  관리자 유저 목록 조회 기능 추가
2. 파라미터로 페이지, 키워드(필수 x) 넘겨줌
3. 유저 아이디, 가입일, 유저 상태가 담긴 리스트 반환

## 📸 결과물 스크린샷
1. **유저 목록 조회**
<img width="1144" alt="스크린샷 2024-06-18 오후 12 14 42" src="https://github.com/ITE-Project1/pick-on-backend/assets/77055216/5d82dbae-b7be-443a-ad43-ef0d44dbeffd">


